### PR TITLE
Add cffi to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pbkdf2
 pycryptodome
 requests
 siphash
+cffi


### PR DESCRIPTION
I needed this python module to run `python libsec_build.py`.